### PR TITLE
add comment about babel-plugin-remove-ungap

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ Ungap utilities are mant to simplify cross browser development without the bloat
   * [@ungap/create-content](https://github.com/ungap/create-content) compatible with all JS engines <sup><sub>(backend via basichtml or others)</sub></sup>
 
 
+## How to exclude these modules
+
+Sometimes you are building a target only for modern browsers, in which case you may
+want to eliminate many of the `@ungap` modules from your bundle.  This can be accomplished
+with [babel-plugin-remove-ungap](https://github.com/cfware/babel-plugin-remove-ungap#readme).
+
+lighterhtml uses this babel plugin to create a "pure ES" bundle of lighterhtml, see
+[rollup config](https://github.com/WebReflection/lighterhtml/blob/master/es.config.js).
+
+
 ## License
 
 Each module is under the [npm](https://www.npmjs.com) default [ISC](https://opensource.org/licenses/ISC) license.


### PR DESCRIPTION
Fixes #3
---
First attempt at updating the README.md, let me know what thoughts you have.

FWIW I'll probably bump to 1.0.0 once I implement an option `include: []`.  This will be used to process modules which are not processed by default - for example I'm going to add support for `@ungap/from-entries` but not process it by default.  This way I can add new `@ungap/*` modules without doing a semver-major bump every time.  Also `Object.fromEntries` is only supported by Firefox 63+ so it's not reasonable to remove `@ungap/from-entries` by default, but some people might still want it.